### PR TITLE
added GitPython to deps for the Optional type import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pyexiv2",
     "requests",
     "deprecated",
+    "GitPython"
 ]
 
 [project.scripts]


### PR DESCRIPTION
The application failed to run for me as the 'Optional' type was imported from GitPython even though it was not listed as dependency.