### PR TITLE
Handle edge cases for query parsing logic

### DIFF
--- a/pinterest_dl/low_level/api/pinterest_api.py
+++ b/pinterest_dl/low_level/api/pinterest_api.py
@@ -35,7 +35,10 @@ class PinterestAPI:
             self.pin_id = self._parse_pin_id(self.url)
         except ValueError:
             self.pin_id = None
-            self.query = self._parse_search_query(self.url)
+            try:
+                self.query = self._parse_search_query(self.url)
+            except ValueError:
+                pass
 
         try:
             self.username, self.boardname = self._parse_board_url(self.url)


### PR DESCRIPTION
Hey @sean1832, cool project!

I see that in the code it does have a logic to parse URL that are formatted like this:
```
https://pinterest.com/{username}/{boardname}
```

However when I tried it, it didn't work. It seems like it tries to parse it as a query URL, but when that didn't work the function returned and doesn't continue to the next parsing logic. 

This PR should fix that behavior. Do let me know