### PR TITLE
fix: add required header for Pinterest API requests

### DIFF
--- a/pinterest_dl/low_level/api/pinterest_api.py
+++ b/pinterest_dl/low_level/api/pinterest_api.py
@@ -53,6 +53,7 @@ class PinterestAPI:
         self._session = requests.Session()
         self._session.cookies.update(self.cookies)  # Update session cookies
         self._session.headers.update({"User-Agent": self.USER_AGENT})
+        self._session.headers.update({"x-pinterest-pws-handler": "www/pin/[id].js"}) # required since 2025-03-07. See https://github.com/sean1832/pinterest-dl/issues/30
         self.is_pin = bool(self.pin_id)
 
     def get_related_images(self, num: int, bookmark: List[str]) -> PinResponse:

--- a/pinterest_dl/low_level/api/pinterest_api.py
+++ b/pinterest_dl/low_level/api/pinterest_api.py
@@ -85,8 +85,9 @@ class PinterestAPI:
         try:
             response_raw_json = response_raw.json()
         except requests.exceptions.JSONDecodeError as e:
-            print(response_raw.text)
-            raise requests.JSONDecodeError(f"Failed to decode JSON response: {e}")
+            raise RuntimeError(
+                f"Failed to decode JSON response: {e}. Response: {response_raw.text}"
+            )
 
         return PinResponse(request_url, response_raw_json)
 


### PR DESCRIPTION
- Added header `{"x-pinterest-pws-handler": "www/pin/[id].js"}` to adapt new Pinterest API update.