### PR TITLE
Add Caption Flags and Request Delay Control & Github Workflow automation

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI on release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pinterest-dl
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel build
+      - name: Build package
+        run: |
+          python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ pinterest-dl [command] [options]
 
 **Scraping Images in anonymous mode:**
 
-Scrape images in anonymous mode, without login, to the `./images/art` directory from the Pinterest URL `https://www.pinterest.com/pin/1234567` with a limit of `30` images and a minimum resolution of `512x512`. Save scraped URLs to a `JSON` file.
+Scrape images in anonymous mode, without login, to the `./images/art` directory from the Pinterest URL `https://www.pinterest.com/pin/1234567` with a num of `30` images and a minimum resolution of `512x512`. Save scraped URLs to a `JSON` file.
 ```bash
-pinterest-dl scrape "https://www.pinterest.com/pin/1234567" "images/art" -l 30 -r 512x512 --json
+pinterest-dl scrape "https://www.pinterest.com/pin/1234567" "images/art" -n 30 -r 512x512 --json
 ```
 
 **Get Browser Cookies:**
@@ -83,7 +83,7 @@ pinterest-dl login -o cookies.json --headful
 
 Scrape images from a private Pinterest board using the cookies saved in the `cookies.json` file.
 ```bash
-pinterest-dl scrape "https://www.pinterest.com/pin/1234567" "images/art" -l 30 -c cookies.json
+pinterest-dl scrape "https://www.pinterest.com/pin/1234567" "images/art" -n 30 -c cookies.json
 ```
 
 > [!TIP]
@@ -133,7 +133,7 @@ pinterest-dl scrape [url] [output_dir] [options]
 **Options:**
 
 - `-c`, `--cookies [file]`: File containing browser cookies for private boards/pins. Run `login` command to obtain cookies.
-- `-l`, `--limit [number]`: Max number of image to download (default: 100).
+- `-n`, `--num [number]`: Max number of image to download (default: 100).
 - `-r`, `--resolution [width]x[height]`: Minimum image resolution for download (e.g., 512x512).
 - `--timeout [second]`: Timeout in seconds for requests (default: 3).
 - `--json`: Save scraped URLs to a JSON file.
@@ -155,7 +155,7 @@ pinterest-dl search [query] [output_dir] [options]
 
 **Options:**
 - `-c`, `--cookies [file]`: File containing browser cookies for private boards/pins. Run `login` command to obtain cookies.
-- `-l`, `--limit [number]`: Max number of image to download (default: 100).
+- `-n`, `--num [number]`: Max number of image to download (default: 100).
 - `-r`, `--resolution [width]x[height]`: Minimum image resolution for download (e.g., 512x512).
 - `--timeout [second]`: Timeout in seconds for requests (default: 3).
 - `--json`: Save scraped URLs to a JSON file.
@@ -194,7 +194,7 @@ images = PinterestDL.with_api(
 ).scrape_and_download(
     url="https://www.pinterest.com/pin/1234567",  # Pinterest URL to scrape
     output_dir="images/art",  # Directory to save downloaded images
-    limit=30,  # Max number of images to download 
+    num=30,  # Max number of images to download 
     min_resolution=(512, 512),  # Minimum resolution for images (width, height) (default: None)
     json_output="art.json",  # File to save URLs of scraped images (default: None)
     dry_run=False,  # If True, performs a scrape without downloading images (default: False)
@@ -215,7 +215,7 @@ images = PinterestDL.with_api(
 ).search_and_download(
     query="art",  # Pinterest search query
     output_dir="images/art",  # Directory to save downloaded images
-    limit=30,  # Max number of images to download 
+    num=30,  # Max number of images to download 
     min_resolution=(512, 512),  # Minimum resolution for images (width, height) (default: None)
     json_output="art.json",  # File to save URLs of scraped images (default: None)
     dry_run=False,  # If True, performs a scrape without downloading images (default: False)
@@ -268,7 +268,7 @@ images = (
     .scrape_and_download(
         url="https://www.pinterest.com/pin/1234567",  # Assume this is a private board URL
         output_dir="images/art",  # Directory to save downloaded images
-        limit=30,  # Max number of images to download
+        num=30,  # Max number of images to download
     )
 )
 ```
@@ -288,7 +288,7 @@ from pinterest_dl import PinterestDL
 # 1. Initialize PinterestDL with API.
 scraped_images = PinterestDL.with_api().scrape(
     url="https://www.pinterest.com/pin/1234567",  # URL of the Pinterest page
-    limit=30,  # Maximum number of images to scrape
+    num=30,  # Maximum number of images to scrape
     min_resolution=(512, 512),  # <- Only available to set in the API. Browser mode will have to pruned after download.
 )
 
@@ -317,7 +317,7 @@ from pinterest_dl import PinterestDL
 # 1. Initialize PinterestDL with API.
 scraped_images = PinterestDL.with_api().search(
     query="art",  # Search query for Pinterest
-    limit=30,  # Maximum number of images to scrape
+    num=30,  # Maximum number of images to scrape
     min_resolution=(512, 512),  # Minimum resolution for images
     delay=0.4, # Delay between requests (default: 0.2)
 )
@@ -336,7 +336,7 @@ scraped_images = PinterestDL.with_browser(
     headless=True,  # Run browser in headless mode
 ).scrape(
     url="https://www.pinterest.com/pin/1234567",  # URL of the Pinterest page
-    limit=30,  # Maximum number of images to scrape
+    num=30,  # Maximum number of images to scrape
 )
 
 # 2. Save Scraped Data to JSON

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -195,7 +195,7 @@ def main() -> None:
 
             # post process
             pruned_idx = PinterestDL.prune_images(downloaded_imgs, args.resolution, args.verbose)
-            PinterestDL.add_captions(downloaded_imgs, pruned_idx, args.verbose)
+            PinterestDL.add_captions_to_meta(downloaded_imgs, pruned_idx, args.verbose)
             print("\nDone.")
         else:
             parser.print_help()

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -48,7 +48,7 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("url", help="URL to scrape images from")
     scrape_cmd.add_argument("output", help="Output directory")
     scrape_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private boards.")
-    scrape_cmd.add_argument("-l", "--limit", type=int, default=100, help="Max number of image to scrape (default: 100)")
+    scrape_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
     scrape_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
     scrape_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
     scrape_cmd.add_argument("--json", action="store_true", help="Write urls to json file")
@@ -64,7 +64,7 @@ def get_parser() -> argparse.ArgumentParser:
     search_cmd.add_argument("query", help="Search query")
     search_cmd.add_argument("output", help="Output directory")
     search_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private boards.")
-    search_cmd.add_argument("-l", "--limit", type=int, default=100, help="Max number of image to scrape (default: 100)")
+    search_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
     search_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
     search_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
     search_cmd.add_argument("--json", action="store_true", help="Write urls to json file")
@@ -117,7 +117,7 @@ def main() -> None:
             )
             print("Example:")
             print(
-                r'    pinterest-dl scrape "https://www.pinterest.com/username/your-board/" "output/pin" -l 10 --cookies .\cookies.json'
+                r'    pinterest-dl scrape "https://www.pinterest.com/username/your-board/" "output/pin" -n 10 --cookies .\cookies.json'
             )
             print("\nDone.")
         elif args.cmd == "scrape":
@@ -131,7 +131,7 @@ def main() -> None:
                 ).with_cookies_path(args.cookies).scrape_and_download(
                     args.url,
                     args.output,
-                    args.limit,
+                    args.num,
                     min_resolution=parse_resolution(args.resolution) if args.resolution else None,
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
@@ -148,7 +148,7 @@ def main() -> None:
                 ).scrape_and_download(
                     args.url,
                     args.output,
-                    args.limit,
+                    args.num,
                     min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
@@ -170,7 +170,7 @@ def main() -> None:
                 ).search_and_download(
                     args.query,
                     args.output,
-                    args.limit,
+                    args.num,
                     min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -55,6 +55,7 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("--json", action="store_true", help="Write urls to json file")
     scrape_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
     scrape_cmd.add_argument("--dry-run", action="store_true", help="Run without download")
+    scrape_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data, 'metadata' embeds in image files, 'none' skips captions (default)")
 
     scrape_cmd.add_argument("--client", default="api", choices=["api", "chrome", "firefox"], help="Client to use for scraping. Chrome/Firefox is slower but more reliable.")
     scrape_cmd.add_argument("--incognito", action="store_true", help="Incognito mode (only for chrome/firefox)")
@@ -72,6 +73,7 @@ def get_parser() -> argparse.ArgumentParser:
     search_cmd.add_argument("--json", action="store_true", help="Write urls to json file")
     search_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
     search_cmd.add_argument("--dry-run", action="store_true", help="Run without download")
+    search_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data, 'metadata' embeds in image files, 'none' skips captions (default)")
 
     search_cmd.add_argument("--client", default="api", choices=["api", "chrome", "firefox"], help="Client to use for scraping. Chrome/Firefox is slower but more reliable.")
     search_cmd.add_argument("--incognito", action="store_true", help="Incognito mode (only for chrome/firefox)")
@@ -83,6 +85,8 @@ def get_parser() -> argparse.ArgumentParser:
     download_cmd.add_argument("-o", "--output", help="Output directory (default: ./<json_filename>)")
     download_cmd.add_argument("-r", "--resolution", type=str, help="minimum resolution to keep (e.g. 512x512).")
     download_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
+    download_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data, 'metadata' embeds in image files, 'none' skips captions (default)")
+
 
     return parser
 # fmt: on
@@ -137,7 +141,7 @@ def main() -> None:
                     min_resolution=parse_resolution(args.resolution) if args.resolution else None,
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
-                    add_captions=True,
+                    caption=args.caption,
                 )
             else:
                 if args.incognito or args.headful:
@@ -154,7 +158,7 @@ def main() -> None:
                     min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
-                    add_captions=True,
+                    caption=args.caption,
                     delay=args.delay,
                 )
 
@@ -177,7 +181,7 @@ def main() -> None:
                     min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
-                    add_captions=True,
+                    caption=args.caption,
                     delay=args.delay,
                 )
 
@@ -195,7 +199,14 @@ def main() -> None:
 
             # post process
             pruned_idx = PinterestDL.prune_images(downloaded_imgs, args.resolution, args.verbose)
-            PinterestDL.add_captions_to_meta(downloaded_imgs, pruned_idx, args.verbose)
+            if args.caption == "txt" or args.caption == "json":
+                PinterestDL.add_captions_to_file(
+                    downloaded_imgs, output_dir, args.caption, args.verbose
+                )
+            elif args.caption == "metadata":
+                PinterestDL.add_captions_to_meta(downloaded_imgs, pruned_idx, args.verbose)
+            elif args.caption != "none":
+                raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
             print("\nDone.")
         else:
             parser.print_help()

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -51,6 +51,7 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
     scrape_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
     scrape_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
+    scrape_cmd.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds (default: 0.2)")
     scrape_cmd.add_argument("--json", action="store_true", help="Write urls to json file")
     scrape_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
     scrape_cmd.add_argument("--dry-run", action="store_true", help="Run without download")
@@ -67,6 +68,7 @@ def get_parser() -> argparse.ArgumentParser:
     search_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
     search_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
     search_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
+    search_cmd.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds (default: 0.2)")
     search_cmd.add_argument("--json", action="store_true", help="Write urls to json file")
     search_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
     search_cmd.add_argument("--dry-run", action="store_true", help="Run without download")
@@ -153,6 +155,7 @@ def main() -> None:
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
                     add_captions=True,
+                    delay=args.delay,
                 )
 
             print("\nDone.")
@@ -175,6 +178,7 @@ def main() -> None:
                     json_output=construct_json_output(args.output) if args.json else None,
                     dry_run=args.dry_run,
                     add_captions=True,
+                    delay=args.delay,
                 )
 
             print("\nDone.")

--- a/pinterest_dl/data_model/pinterest_image.py
+++ b/pinterest_dl/data_model/pinterest_image.py
@@ -61,13 +61,13 @@ class PinterestImage:
             return True
         return False
 
-    def write_comment(self, comment: str) -> None:
+    def meta_write_comment(self, comment: str) -> None:
         if not self.local_path:
             raise ValueError("Local path not set.")
         with pyexiv2.Image(str(self.local_path)) as img:
             img.modify_exif({"Exif.Image.XPComment": comment})
 
-    def write_subject(self, subject: str) -> None:
+    def meta_write_subject(self, subject: str) -> None:
         if not self.local_path:
             raise ValueError("Local path not set.")
         with pyexiv2.Image(str(self.local_path)) as img:

--- a/pinterest_dl/low_level/api/pinterest_api.py
+++ b/pinterest_dl/low_level/api/pinterest_api.py
@@ -188,8 +188,12 @@ class PinterestAPI:
             response_raw = self._session.get(request_url, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise requests.RequestException(f"Failed to request search: {e}")
-
-        return PinResponse(request_url, response_raw.json())
+        try:
+            json_response = response_raw.json()
+        except requests.exceptions.JSONDecodeError as e:
+            print(response_raw.text)
+            raise requests.JSONDecodeError(f"Failed to decode JSON response: {e}")
+        return PinResponse(request_url, json_response)
 
     def _validate_num(self, num: int) -> None:
         if num < 1:

--- a/pinterest_dl/low_level/webdriver/pinterest_driver.py
+++ b/pinterest_dl/low_level/webdriver/pinterest_driver.py
@@ -61,7 +61,7 @@ class PinterestDriver:
     def scrape(
         self,
         url: str,
-        limit: int = 20,
+        num: int = 20,
         timeout: float = 3,
         verbose: bool = False,
     ) -> List[PinterestImage]:
@@ -69,10 +69,10 @@ class PinterestDriver:
         imgs_data: List[PinterestImage] = []  # Store image data
         previous_divs = []
         tries = 0
-        pbar = tqdm(total=limit, desc="Scraping")
+        pbar = tqdm(total=num, desc="Scraping")
         try:
             self.webdriver.get(url)
-            while len(unique_results) < limit:
+            while len(unique_results) < num:
                 try:
                     divs = self.webdriver.find_elements(By.CSS_SELECTOR, "div[data-test-id='pin']")
                     if divs == previous_divs:
@@ -85,7 +85,7 @@ class PinterestDriver:
                         break
 
                     for div in divs:
-                        if self._is_div_ad(div) or len(unique_results) >= limit:
+                        if self._is_div_ad(div) or len(unique_results) >= num:
                             continue
                         images = div.find_elements(By.TAG_NAME, "img")
                         href = div.find_element(By.TAG_NAME, "a").get_attribute("href")
@@ -102,7 +102,7 @@ class PinterestDriver:
                                     pbar.update(1)
                                     if verbose:
                                         print(src, alt)
-                                    if len(unique_results) >= limit:
+                                    if len(unique_results) >= num:
                                         break
 
                     previous_divs = copy.copy(divs)  # copy to avoid reference

--- a/pinterest_dl/scrapers/scraper_api.py
+++ b/pinterest_dl/scrapers/scraper_api.py
@@ -1,6 +1,6 @@
 import time
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Literal, Optional, Tuple, Union
 
 from tqdm import tqdm
 
@@ -111,7 +111,7 @@ class _ScraperAPI(_ScraperBase):
         min_resolution: Tuple[int, int] = (0, 0),
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
-        add_captions: bool = False,
+        caption: Literal["txt", "json", "metadata", "none"] = "none",
         delay: float = 0.2,
     ) -> Optional[List[PinterestImage]]:
         """Scrape pins from Pinterest and download images.
@@ -123,7 +123,11 @@ class _ScraperAPI(_ScraperBase):
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
-            add_captions (bool): Add captions to downloaded images.
+            caption (Literal["txt", "json", "metadata", "none"]): Caption mode for downloaded images.
+                'txt' for alt text in separate files, 
+                'json' for full image data, 
+                'metadata' embeds in image files, 
+                'none' skips captions
             delay (float): Delay in seconds between requests.
 
         Returns:
@@ -146,8 +150,12 @@ class _ScraperAPI(_ScraperBase):
 
         valid_indices = []
 
-        if add_captions:
+        if caption == "txt" or caption == "json":
+            self.add_captions_to_file(downloaded_imgs, output_dir, caption, self.verbose)
+        elif caption == "metadata":
             self.add_captions_to_meta(downloaded_imgs, valid_indices, self.verbose)
+        elif caption != "none":
+            raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
 
         return downloaded_imgs
 
@@ -219,7 +227,7 @@ class _ScraperAPI(_ScraperBase):
         min_resolution: Tuple[int, int] = (0, 0),
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
-        add_captions: bool = False,
+        caption: Literal["txt", "json", "metadata", "none"] = "none",
         delay: float = 0.2,
     ) -> Optional[List[PinterestImage]]:
         """Search for images on Pinterest and download them.
@@ -231,7 +239,11 @@ class _ScraperAPI(_ScraperBase):
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
-            add_captions (bool): Add captions to downloaded images.
+            caption (Literal["txt", "json", "metadata", "none"]): Caption mode for downloaded images.
+                'txt' for alt text in separate files, 
+                'json' for full image data, 
+                'metadata' embeds in image files, 
+                'none' skips captions
             delay (float): Delay in seconds between requests.
 
         Returns:
@@ -253,8 +265,12 @@ class _ScraperAPI(_ScraperBase):
 
         valid_indices = []
 
-        if add_captions:
+        if caption == "txt" or caption == "json":
+            self.add_captions_to_file(downloaded_imgs, output_dir, caption, self.verbose)
+        elif caption == "metadata":
             self.add_captions_to_meta(downloaded_imgs, valid_indices, self.verbose)
+        elif caption != "none":
+            raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
 
         return downloaded_imgs
 

--- a/pinterest_dl/scrapers/scraper_api.py
+++ b/pinterest_dl/scrapers/scraper_api.py
@@ -1,6 +1,6 @@
 import time
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Any
+from typing import Any, List, Optional, Tuple, Union
 
 from tqdm import tqdm
 
@@ -28,7 +28,7 @@ class _ScraperAPI(_ScraperBase):
         self.verbose = verbose
         self.cookies = None
 
-    def with_cookies(self, cookies:list[dict[str, Any]]) -> "_ScraperAPI":
+    def with_cookies(self, cookies: list[dict[str, Any]]) -> "_ScraperAPI":
         """Load cookies to the current session.
 
         Args:
@@ -38,10 +38,14 @@ class _ScraperAPI(_ScraperBase):
             _ScraperAPI: Instance of ScraperAPI with cookies loaded.
         """
         if isinstance(cookies, str) or isinstance(cookies, Path):
-            raise ValueError("Invalid cookies format. Expected a list of dictionary. In Selenium format."+
-                             "If you want to load cookies from a file, use `with_cookies_path` method instead.")
+            raise ValueError(
+                "Invalid cookies format. Expected a list of dictionary. In Selenium format."
+                + "If you want to load cookies from a file, use `with_cookies_path` method instead."
+            )
         if not isinstance(cookies, list):
-            raise ValueError("Invalid cookies format. Expected a list of dictionary. In Selenium format.")
+            raise ValueError(
+                "Invalid cookies format. Expected a list of dictionary. In Selenium format."
+            )
         self.cookies = PinterestCookieJar().from_selenium_cookies(cookies)
         return self
 
@@ -108,6 +112,7 @@ class _ScraperAPI(_ScraperBase):
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
         add_captions: bool = False,
+        delay: float = 0.2,
     ) -> Optional[List[PinterestImage]]:
         """Scrape pins from Pinterest and download images.
 
@@ -119,14 +124,15 @@ class _ScraperAPI(_ScraperBase):
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
             add_captions (bool): Add captions to downloaded images.
+            delay (float): Delay in seconds between requests.
 
         Returns:
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
         """
-        scraped_imgs = self.scrape(url, num, min_resolution)
+        scraped_imgs = self.scrape(url, num, min_resolution, delay)
 
         imgs_dict = [img.to_dict() for img in scraped_imgs]
-        
+
         if json_output:
             output_path = Path(json_output)
             io.write_json(imgs_dict, output_path, indent=4)
@@ -214,6 +220,7 @@ class _ScraperAPI(_ScraperBase):
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
         add_captions: bool = False,
+        delay: float = 0.2,
     ) -> Optional[List[PinterestImage]]:
         """Search for images on Pinterest and download them.
 
@@ -225,11 +232,12 @@ class _ScraperAPI(_ScraperBase):
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
             add_captions (bool): Add captions to downloaded images.
+            delay (float): Delay in seconds between requests.
 
         Returns:
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
         """
-        scraped_imgs = self.search(query, num, min_resolution)
+        scraped_imgs = self.search(query, num, min_resolution, delay)
 
         if json_output:
             output_path = Path(json_output)

--- a/pinterest_dl/scrapers/scraper_api.py
+++ b/pinterest_dl/scrapers/scraper_api.py
@@ -125,9 +125,10 @@ class _ScraperAPI(_ScraperBase):
         """
         scraped_imgs = self.scrape(url, limit, min_resolution)
 
+        imgs_dict = [img.to_dict() for img in scraped_imgs]
+        
         if json_output:
             output_path = Path(json_output)
-            imgs_dict = [img.to_dict() for img in scraped_imgs]
             io.write_json(imgs_dict, output_path, indent=4)
 
         if dry_run:

--- a/pinterest_dl/scrapers/scraper_api.py
+++ b/pinterest_dl/scrapers/scraper_api.py
@@ -70,13 +70,13 @@ class _ScraperAPI(_ScraperBase):
         return self
 
     def scrape(
-        self, url: str, limit: int, min_resolution: Tuple[int, int] = (0, 0), delay: float = 0.2
+        self, url: str, num: int, min_resolution: Tuple[int, int] = (0, 0), delay: float = 0.2
     ) -> List[PinterestImage]:
         """Scrape pins from Pinterest using the API.
 
         Args:
             url (str): Pinterest URL to scrape.
-            limit (int): Maximum number of images to scrape.
+            num (int): Maximum number of images to scrape.
             delay (float): Delay in seconds between requests.
 
         Returns:
@@ -88,9 +88,9 @@ class _ScraperAPI(_ScraperBase):
         bookmarks = BookmarkManager(2)
 
         if api.is_pin:
-            images = self._scrape_pins(api, limit, min_resolution, delay, bookmarks)
+            images = self._scrape_pins(api, num, min_resolution, delay, bookmarks)
         else:
-            images = self._scrape_board(api, limit, min_resolution, delay, bookmarks)
+            images = self._scrape_board(api, num, min_resolution, delay, bookmarks)
 
         if self.verbose:
             self._display_images(images)
@@ -103,7 +103,7 @@ class _ScraperAPI(_ScraperBase):
         self,
         url: str,
         output_dir: Union[str, Path],
-        limit: int,
+        num: int,
         min_resolution: Tuple[int, int] = (0, 0),
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
@@ -114,7 +114,7 @@ class _ScraperAPI(_ScraperBase):
         Args:
             url (str): Pinterest URL to scrape.
             output_dir (Union[str, Path]): Directory to store downloaded images.
-            limit (int): Maximum number of images to scrape.
+            num (int): Maximum number of images to scrape.
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
@@ -123,7 +123,7 @@ class _ScraperAPI(_ScraperBase):
         Returns:
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
         """
-        scraped_imgs = self.scrape(url, limit, min_resolution)
+        scraped_imgs = self.scrape(url, num, min_resolution)
 
         imgs_dict = [img.to_dict() for img in scraped_imgs]
         
@@ -148,7 +148,7 @@ class _ScraperAPI(_ScraperBase):
     def search(
         self,
         query: str,
-        limit: int,
+        num: int,
         min_resolution: Tuple[int, int],
         delay: float = 0.2,
         bookmarksCount: int = 1,
@@ -157,7 +157,7 @@ class _ScraperAPI(_ScraperBase):
 
         Args:
             query (str): query to search.
-            limit (int): Maximum number of images to scrape.
+            num (int): Maximum number of images to scrape.
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             delay (float): Delay in seconds between requests in second. Defaults to 0.2.
             bookmarksCount (int, optional): Number of bookmarks to keep. Defaults to 1.
@@ -166,7 +166,7 @@ class _ScraperAPI(_ScraperBase):
             List[PinterestImage]: List of scraped PinterestImage objects.
         """
         images = []
-        remains = limit
+        remains = num
         batch_count = 0
 
         if " " in query:
@@ -178,7 +178,7 @@ class _ScraperAPI(_ScraperBase):
         api = PinterestAPI(url, self.cookies, timeout=self.timeout)
         bookmarks = BookmarkManager(bookmarksCount)
 
-        with tqdm(total=limit, desc="Scraping Search", disable=self.verbose) as pbar:
+        with tqdm(total=num, desc="Scraping Search", disable=self.verbose) as pbar:
             while remains > 0:
                 batch_size = min(50, remains)
                 current_img_batch, bookmarks = self._search_images(
@@ -209,7 +209,7 @@ class _ScraperAPI(_ScraperBase):
         self,
         query: str,
         output_dir: Union[str, Path],
-        limit: int,
+        num: int,
         min_resolution: Tuple[int, int] = (0, 0),
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
@@ -220,7 +220,7 @@ class _ScraperAPI(_ScraperBase):
         Args:
             url (str): Pinterest URL to scrape.
             output_dir (Union[str, Path]): Directory to store downloaded images.
-            limit (int): Maximum number of images to scrape.
+            num (int): Maximum number of images to scrape.
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
@@ -229,7 +229,7 @@ class _ScraperAPI(_ScraperBase):
         Returns:
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
         """
-        scraped_imgs = self.search(query, limit, min_resolution)
+        scraped_imgs = self.search(query, num, min_resolution)
 
         if json_output:
             output_path = Path(json_output)
@@ -253,16 +253,16 @@ class _ScraperAPI(_ScraperBase):
     def _scrape_pins(
         self,
         api: PinterestAPI,
-        limit: int,
+        num: int,
         min_resolution: Tuple[int, int],
         delay: float,
         bookmarks: BookmarkManager,
     ) -> List[PinterestImage]:
         """Scrape pins from a specific Pinterest pin URL."""
         images = []
-        remains = limit
+        remains = num
 
-        with tqdm(total=limit, desc="Scraping Pins", disable=self.verbose) as pbar:
+        with tqdm(total=num, desc="Scraping Pins", disable=self.verbose) as pbar:
             while remains > 0:
                 batch_size = min(50, remains)
                 current_img_batch, bookmarks = self._get_images(
@@ -287,7 +287,7 @@ class _ScraperAPI(_ScraperBase):
     def _scrape_board(
         self,
         api: PinterestAPI,
-        limit: int,
+        num: int,
         min_resolution: Tuple[int, int],
         delay: float,
         bookmarks: BookmarkManager,
@@ -297,13 +297,13 @@ class _ScraperAPI(_ScraperBase):
         board_info = api.get_board()
         board_id = board_info.get_board_id()
         pin_count = board_info.get_pin_count()
-        limit = min(limit, pin_count)
-        remains = limit
+        num = min(num, pin_count)
+        remains = num
 
         if self.verbose:
             print(f"Scraping board resource with {pin_count} pins (ID: {board_id})...")
 
-        with tqdm(total=limit, desc="Scraping Board", disable=self.verbose) as pbar:
+        with tqdm(total=num, desc="Scraping Board", disable=self.verbose) as pbar:
             while remains > 0:
                 batch_size = min(50, remains)
                 current_img_batch, bookmarks = self._get_images(

--- a/pinterest_dl/scrapers/scraper_api.py
+++ b/pinterest_dl/scrapers/scraper_api.py
@@ -147,7 +147,7 @@ class _ScraperAPI(_ScraperBase):
         valid_indices = []
 
         if add_captions:
-            self.add_captions(downloaded_imgs, valid_indices, self.verbose)
+            self.add_captions_to_meta(downloaded_imgs, valid_indices, self.verbose)
 
         return downloaded_imgs
 
@@ -254,7 +254,7 @@ class _ScraperAPI(_ScraperBase):
         valid_indices = []
 
         if add_captions:
-            self.add_captions(downloaded_imgs, valid_indices, self.verbose)
+            self.add_captions_to_meta(downloaded_imgs, valid_indices, self.verbose)
 
         return downloaded_imgs
 

--- a/pinterest_dl/scrapers/scraper_base.py
+++ b/pinterest_dl/scrapers/scraper_base.py
@@ -55,6 +55,7 @@ class _ScraperBase:
             indices_list = indices
 
         for index in tqdm.tqdm(indices_list, desc="Captioning", disable=verbose):
+            img = None
             try:
                 img = images[index]
                 if not img.local_path:
@@ -73,7 +74,10 @@ class _ScraperBase:
                         print(f"Caption added to {img.local_path}: '{img.alt}'")
 
             except Exception as e:
-                print(f"Error captioning {img.local_path}: {e}")
+                if img:
+                    print(f"Error captioning {img.local_path}: {e}")
+                else:
+                    print(f"Error captioning image at index {index}: {e}")
 
     @staticmethod
     def prune_images(

--- a/pinterest_dl/scrapers/scraper_base.py
+++ b/pinterest_dl/scrapers/scraper_base.py
@@ -65,11 +65,11 @@ class _ScraperBase:
                         print(f"Skipping captioning for {img.local_path} (GIF)")
                     continue
                 if img.origin:
-                    img.write_comment(img.origin)
+                    img.meta_write_comment(img.origin)
                     if verbose:
                         print(f"Origin added to {img.local_path}: '{img.origin}'")
                 if img.alt:
-                    img.write_subject(img.alt)
+                    img.meta_write_subject(img.alt)
                     if verbose:
                         print(f"Caption added to {img.local_path}: '{img.alt}'")
 

--- a/pinterest_dl/scrapers/scraper_base.py
+++ b/pinterest_dl/scrapers/scraper_base.py
@@ -1,5 +1,6 @@
+import json
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 import tqdm
 
@@ -39,7 +40,7 @@ class _ScraperBase:
         return images
 
     @staticmethod
-    def add_captions(
+    def add_captions_to_meta(
         images: List[PinterestImage], indices: Optional[List[int]] = None, verbose: bool = False
     ) -> None:
         """Add captions and origin information to downloaded images.

--- a/pinterest_dl/scrapers/scraper_webdriver.py
+++ b/pinterest_dl/scrapers/scraper_webdriver.py
@@ -75,19 +75,19 @@ class _ScraperWebdriver(_ScraperBase):
         time.sleep(wait_sec)
         return self
 
-    def scrape(self, url: str, limit: int) -> List[PinterestImage]:
+    def scrape(self, url: str, num: int) -> List[PinterestImage]:
         """Scrape pins from Pinterest using a WebDriver.
 
         Args:
             url (str): Pinterest URL to scrape.
-            limit (int): Maximum number of images to scrape.
+            num (int): Maximum number of images to scrape.
 
         Returns:
             List[PinterestImage]: List of scraped PinterestImage objects.
         """
         try:
             pin_scraper = PinterestDriver(self.webdriver)
-            return pin_scraper.scrape(url, limit=limit, verbose=self.verbose, timeout=self.timeout)
+            return pin_scraper.scrape(url, num=num, verbose=self.verbose, timeout=self.timeout)
         finally:
             self.webdriver.close()
 
@@ -95,7 +95,7 @@ class _ScraperWebdriver(_ScraperBase):
         self,
         url: str,
         output_dir: Union[str, Path],
-        limit: int,
+        num: int,
         min_resolution: Optional[Tuple[int, int]] = None,
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
@@ -106,7 +106,7 @@ class _ScraperWebdriver(_ScraperBase):
         Args:
             url (str): Pinterest URL to scrape.
             output_dir (Union[str, Path]): Directory to store downloaded images.
-            limit (int): Maximum number of images to scrape.
+            num (int): Maximum number of images to scrape.
             min_resolution (Optional[Tuple[int, int]]): Minimum resolution for pruning.
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
@@ -116,7 +116,7 @@ class _ScraperWebdriver(_ScraperBase):
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
         """
         min_resolution = min_resolution or (0, 0)
-        scraped_imgs = self.scrape(url, limit)
+        scraped_imgs = self.scrape(url, num)
 
         imgs_dict = [img.to_dict() for img in scraped_imgs]
         if json_output:

--- a/pinterest_dl/scrapers/scraper_webdriver.py
+++ b/pinterest_dl/scrapers/scraper_webdriver.py
@@ -118,9 +118,9 @@ class _ScraperWebdriver(_ScraperBase):
         min_resolution = min_resolution or (0, 0)
         scraped_imgs = self.scrape(url, limit)
 
+        imgs_dict = [img.to_dict() for img in scraped_imgs]
         if json_output:
             output_path = Path(json_output)
-            imgs_dict = [img.to_dict() for img in scraped_imgs]
             io.write_json(imgs_dict, output_path, indent=4)
 
         if dry_run:

--- a/pinterest_dl/scrapers/scraper_webdriver.py
+++ b/pinterest_dl/scrapers/scraper_webdriver.py
@@ -105,7 +105,7 @@ class _ScraperWebdriver(_ScraperBase):
         min_resolution: Optional[Tuple[int, int]] = None,
         json_output: Optional[Union[str, Path]] = None,
         dry_run: bool = False,
-        add_captions: bool = False,
+        caption: Literal["txt", "json", "metadata", "none"] = "none",
     ) -> Optional[List[PinterestImage]]:
         """Scrape pins from Pinterest and download images.
 
@@ -116,7 +116,11 @@ class _ScraperWebdriver(_ScraperBase):
             min_resolution (Optional[Tuple[int, int]]): Minimum resolution for pruning.
             json_output (Optional[Union[str, Path]]): Path to save scraped data as JSON.
             dry_run (bool): Only scrape URLs without downloading images.
-            add_captions (bool): Add captions to downloaded images.
+            caption (Literal["txt", "json", "metadata", "none"]): Caption mode for downloaded images.
+                'txt' for alt text in separate files,
+                'json' for full image data,
+                'metadata' embeds in image files,
+                'none' skips captions
 
         Returns:
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
@@ -138,8 +142,12 @@ class _ScraperWebdriver(_ScraperBase):
 
         valid_indices = self.prune_images(downloaded_imgs, min_resolution or (0, 0), self.verbose)
 
-        if add_captions:
+        if caption == "txt" or caption == "json":
+            self.add_captions_to_file(downloaded_imgs, output_dir, caption, self.verbose)
+        elif caption == "metadata":
             self.add_captions_to_meta(downloaded_imgs, valid_indices, self.verbose)
+        elif caption != "none":
+            raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
 
         return downloaded_imgs
 

--- a/pinterest_dl/scrapers/scraper_webdriver.py
+++ b/pinterest_dl/scrapers/scraper_webdriver.py
@@ -17,7 +17,9 @@ class _ScraperWebdriver(_ScraperBase):
         self.verbose = verbose
         self.webdriver: WebDriver = webdriver
 
-    def with_cookies(self, cookies: list[dict[str, Any]], wait_sec: float = 1) -> "_ScraperWebdriver":
+    def with_cookies(
+        self, cookies: list[dict[str, Any]], wait_sec: float = 1
+    ) -> "_ScraperWebdriver":
         """Load cookies to the current browser session.
 
         Args:
@@ -28,10 +30,14 @@ class _ScraperWebdriver(_ScraperBase):
             _ScraperWebdriver: Instance of ScraperWebdriver with cookies loaded.
         """
         if isinstance(cookies, str) or isinstance(cookies, Path):
-            raise ValueError("Invalid cookies format. Expected a list of dictionary. In Selenium format."+
-                             "If you want to load cookies from a file, use `with_cookies_path` method instead.")
+            raise ValueError(
+                "Invalid cookies format. Expected a list of dictionary. In Selenium format."
+                + "If you want to load cookies from a file, use `with_cookies_path` method instead."
+            )
         if not isinstance(cookies, list):
-            raise ValueError("Invalid cookies format. Expected a list of dictionary. In Selenium format.")
+            raise ValueError(
+                "Invalid cookies format. Expected a list of dictionary. In Selenium format."
+            )
         cookies = self._sanitize_cookies(cookies)
         for cookie in cookies:
             self.webdriver.add_cookie(cookie)
@@ -133,7 +139,7 @@ class _ScraperWebdriver(_ScraperBase):
         valid_indices = self.prune_images(downloaded_imgs, min_resolution or (0, 0), self.verbose)
 
         if add_captions:
-            self.add_captions(downloaded_imgs, valid_indices, self.verbose)
+            self.add_captions_to_meta(downloaded_imgs, valid_indices, self.verbose)
 
         return downloaded_imgs
 


### PR DESCRIPTION
### Change Type
- [x] :sparkles: feat
- [x] :bug: fix
- [x] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?

### Change Log
- **feat**
  - Add GitHub Actions workflow for PyPI release automation (df9a164)
  - Implement `--caption` flags for `scrape`, `search` and `download` commands (0ec1115)
  - Add `--delay` argument for controlling request timing (e48b709)
- **fix**
  - Handle JSON decoding errors in Pinterest API response (0d89bd8)
  - Avoid redundant creation of imgs_dict in JSON output (36eb5ad)
  - Handle uninitialized image variable in captioning process (dc108c7)
  - Fix potentially unbound `imgs_dict` variable (d5b682c)
  - Rename 'limit' parameter to 'num' for clarity (7d53025)
- **refactor**
  - Rename add_captions method to add_captions_to_meta for clarity (e50fa0d)
  - Rename comment and subject methods for improved clarity (56aa60e)

### Note
This release introduces several new features including PyPI release automation and command-line flags for caption handling. Multiple bug fixes address stability issues in JSON handling and variable initialization. Method renaming improves code clarity and maintainability.