### PR TITLE
Replace positional output argument with `-o`/`--output` flags and integrate dry run behavior

### DIFF
--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -2,14 +2,21 @@ import argparse
 from getpass import getpass
 from pathlib import Path
 from traceback import print_exc
+from typing import Optional
 
 from pinterest_dl import PinterestDL, __description__, __version__
 from pinterest_dl.data_model.pinterest_image import PinterestImage
 from pinterest_dl.low_level.ops import io
+from datetime import datetime
 
 
-def build_cache_name(output_dir: Path) -> Path:
-    return Path(f"{Path(output_dir).absolute().name}.json")
+def build_cache_name(output_dir: Optional[Path]) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    if output_dir is None:
+        filename = f"{timestamp}.json"
+    else:
+        filename = f"{Path(output_dir).absolute().name}_{timestamp}.json"
+    return Path(filename)
 
 
 def parse_resolution(resolution: str) -> tuple[int, int]:
@@ -46,7 +53,7 @@ def get_parser() -> argparse.ArgumentParser:
     # scrape command
     scrape_cmd = cmd.add_parser("scrape", help="Scrape images from Pinterest")
     scrape_cmd.add_argument("url", help="URL to scrape images from")
-    scrape_cmd.add_argument("output", help="Output directory")
+    scrape_cmd.add_argument("-o", "--output",type=str, help="Output directory")
     scrape_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private boards.")
     scrape_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
     scrape_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
@@ -54,7 +61,6 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds (default: 0.2)")
     scrape_cmd.add_argument("--cache", action="store_true", help="cache URLs into json file for reuse")
     scrape_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
-    scrape_cmd.add_argument("--dry-run", action="store_true", help="Run without download")
     scrape_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data in seperate file, 'metadata' embeds in image files, 'none' skips captions (default)")
 
     scrape_cmd.add_argument("--client", default="api", choices=["api", "chrome", "firefox"], help="Client to use for scraping. Chrome/Firefox is slower but more reliable.")
@@ -64,7 +70,7 @@ def get_parser() -> argparse.ArgumentParser:
     # search command
     search_cmd = cmd.add_parser("search", help="Search images from Pinterest")
     search_cmd.add_argument("query", help="Search query")
-    search_cmd.add_argument("output", help="Output directory")
+    search_cmd.add_argument("-o", "--output",type=str, help="Output directory")
     search_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private boards.")
     search_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
     search_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
@@ -72,7 +78,6 @@ def get_parser() -> argparse.ArgumentParser:
     search_cmd.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds (default: 0.2)")
     search_cmd.add_argument("--cache", action="store_true", help="cache URLs into json file for reuse")
     search_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
-    search_cmd.add_argument("--dry-run", action="store_true", help="Run without download")
     search_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data in seperate file, 'metadata' embeds in image files, 'none' skips captions (default)")
 
     search_cmd.add_argument("--client", default="api", choices=["api", "chrome", "firefox"], help="Client to use for scraping. Chrome/Firefox is slower but more reliable.")
@@ -140,7 +145,6 @@ def main() -> None:
                     args.num,
                     min_resolution=parse_resolution(args.resolution) if args.resolution else None,
                     cache_path=build_cache_name(args.output) if args.cache else None,
-                    dry_run=args.dry_run,
                     caption=args.caption,
                 )
             else:
@@ -157,7 +161,6 @@ def main() -> None:
                     args.num,
                     min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
                     cache_path=build_cache_name(args.output) if args.cache else None,
-                    dry_run=args.dry_run,
                     caption=args.caption,
                     delay=args.delay,
                 )
@@ -180,7 +183,6 @@ def main() -> None:
                     args.num,
                     min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
                     cache_path=build_cache_name(args.output) if args.cache else None,
-                    dry_run=args.dry_run,
                     caption=args.caption,
                     delay=args.delay,
                 )

--- a/pinterest_dl/scrapers/scraper_api.py
+++ b/pinterest_dl/scrapers/scraper_api.py
@@ -1,3 +1,4 @@
+import json
 import time
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
@@ -106,11 +107,10 @@ class _ScraperAPI(_ScraperBase):
     def scrape_and_download(
         self,
         url: str,
-        output_dir: Union[str, Path],
+        output_dir: Optional[Union[str, Path]],
         num: int,
         min_resolution: Tuple[int, int] = (0, 0),
         cache_path: Optional[Union[str, Path]] = None,
-        dry_run: bool = False,
         caption: Literal["txt", "json", "metadata", "none"] = "none",
         delay: float = 0.2,
     ) -> Optional[List[PinterestImage]]:
@@ -118,11 +118,10 @@ class _ScraperAPI(_ScraperBase):
 
         Args:
             url (str): Pinterest URL to scrape.
-            output_dir (Union[str, Path]): Directory to store downloaded images.
+            output_dir (Optional[Union[str, Path]]): Directory to store downloaded images. 'None' print to console.
             num (int): Maximum number of images to scrape.
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             cache_path (Optional[Union[str, Path]]): Path to cache scraped data as json
-            dry_run (bool): Only scrape URLs without downloading images.
             caption (Literal["txt", "json", "metadata", "none"]): Caption mode for downloaded images.
                 'txt' for alt text in separate files,
                 'json' for full image data,
@@ -137,13 +136,17 @@ class _ScraperAPI(_ScraperBase):
 
         imgs_dict = [img.to_dict() for img in scraped_imgs]
 
+        if not output_dir:
+            # no output_dir provided, print the scraped image data to console
+            print("Scraped: ")
+            print(json.dumps(imgs_dict, indent=2))
+
         if cache_path:
             output_path = Path(cache_path)
             io.write_json(imgs_dict, output_path, indent=4)
+            print(f"Scraped data cached to {output_path}")
 
-        if dry_run:
-            if self.verbose:
-                print("Scraped data (dry run):", imgs_dict)
+        if not output_dir:
             return None
 
         downloaded_imgs = self.download_images(scraped_imgs, output_dir, self.verbose)
@@ -222,11 +225,10 @@ class _ScraperAPI(_ScraperBase):
     def search_and_download(
         self,
         query: str,
-        output_dir: Union[str, Path],
+        output_dir: Optional[Union[str, Path]],
         num: int,
         min_resolution: Tuple[int, int] = (0, 0),
         cache_path: Optional[Union[str, Path]] = None,
-        dry_run: bool = False,
         caption: Literal["txt", "json", "metadata", "none"] = "none",
         delay: float = 0.2,
     ) -> Optional[List[PinterestImage]]:
@@ -234,11 +236,10 @@ class _ScraperAPI(_ScraperBase):
 
         Args:
             url (str): Pinterest URL to scrape.
-            output_dir (Union[str, Path]): Directory to store downloaded images.
+            output_dir (Optional[Union[str, Path]]): Directory to store downloaded images. 'None' print to console.
             num (int): Maximum number of images to scrape.
             min_resolution (Tuple[int, int]): Minimum resolution for pruning. (width, height). (0, 0) to download all images.
             cache_path (Optional[Union[str, Path]]): Path to cache scraped data as json
-            dry_run (bool): Only scrape URLs without downloading images.
             caption (Literal["txt", "json", "metadata", "none"]): Caption mode for downloaded images.
                 'txt' for alt text in separate files,
                 'json' for full image data,
@@ -250,15 +251,19 @@ class _ScraperAPI(_ScraperBase):
             Optional[List[PinterestImage]]: List of downloaded PinterestImage objects.
         """
         scraped_imgs = self.search(query, num, min_resolution, delay)
+        imgs_dict = [img.to_dict() for img in scraped_imgs]
+
+        if not output_dir:
+            # no output_dir provided, print the scraped image data to console
+            print("Scraped: ")
+            print(json.dumps(imgs_dict, indent=2))
 
         if cache_path:
             output_path = Path(cache_path)
-            imgs_dict = [img.to_dict() for img in scraped_imgs]
             io.write_json(imgs_dict, output_path, indent=4)
+            print(f"Scraped data cached to {output_path}")
 
-        if dry_run:
-            # if self.verbose:
-            #     print("Scraped data (dry run):", imgs_dict)
+        if not output_dir:
             return None
 
         downloaded_imgs = self.download_images(scraped_imgs, output_dir, self.verbose)

--- a/pinterest_dl/scrapers/scraper_webdriver.py
+++ b/pinterest_dl/scrapers/scraper_webdriver.py
@@ -1,3 +1,4 @@
+import json
 import time
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
@@ -100,22 +101,20 @@ class _ScraperWebdriver(_ScraperBase):
     def scrape_and_download(
         self,
         url: str,
-        output_dir: Union[str, Path],
+        output_dir: Optional[Union[str, Path]],
         num: int,
         min_resolution: Optional[Tuple[int, int]] = None,
         cache_path: Optional[Union[str, Path]] = None,
-        dry_run: bool = False,
         caption: Literal["txt", "json", "metadata", "none"] = "none",
     ) -> Optional[List[PinterestImage]]:
         """Scrape pins from Pinterest and download images.
 
         Args:
             url (str): Pinterest URL to scrape.
-            output_dir (Union[str, Path]): Directory to store downloaded images.
+            output_dir (Union[str, Path]): Directory to store downloaded images. 'None' print to console.
             num (int): Maximum number of images to scrape.
             min_resolution (Optional[Tuple[int, int]]): Minimum resolution for pruning.
             cache_path (Optional[Union[str, Path]]): Path to cache scraped data as json
-            dry_run (bool): Only scrape URLs without downloading images.
             caption (Literal["txt", "json", "metadata", "none"]): Caption mode for downloaded images.
                 'txt' for alt text in separate files,
                 'json' for full image data,
@@ -129,13 +128,18 @@ class _ScraperWebdriver(_ScraperBase):
         scraped_imgs = self.scrape(url, num)
 
         imgs_dict = [img.to_dict() for img in scraped_imgs]
+
+        if not output_dir:
+            # no output_dir provided, print the scraped image data to console
+            print("Scraped: ")
+            print(json.dumps(imgs_dict, indent=2))
+
         if cache_path:
             output_path = Path(cache_path)
             io.write_json(imgs_dict, output_path, indent=4)
+            print(f"Scraped data cached to {output_path}")
 
-        if dry_run:
-            if self.verbose:
-                print("Scraped data (dry run):", imgs_dict)
+        if not output_dir:
             return None
 
         downloaded_imgs = self.download_images(scraped_imgs, output_dir, self.verbose)


### PR DESCRIPTION
### Change Type
- [x] :sparkles: feat
- [ ] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [x] Does this PR require a documentation update?

### Change Log
- **feat**
  - Replaced positional output argument with `-o`/`--output` flags (227112e, 2180ffc)
  - Made `output_dir` optional with None falling back to console output (227112e)
  - Integrated dry run behavior directly into output handling (227112e, 2180ffc)
  - CLI now accepts both `-o` and `--output` options (2180ffc)

### Note
This change simplifies the CLI interface by:
1. Replacing the positional output argument with standard flag options (`-o`/`--output`)
2. Integrating the dry run functionality directly into the output handling logic
3. Making console output the default behavior when no output directory is specified