### PR TITLE
fix: replace incorrect import of Optional from git to typing

### DIFF
--- a/pinterest_dl/low_level/api/pinterest_api.py
+++ b/pinterest_dl/low_level/api/pinterest_api.py
@@ -2,7 +2,7 @@ import re
 from typing import List, Tuple
 
 import requests
-from git import Optional
+from typing import Optional
 
 from pinterest_dl.data_model.cookie import PinterestCookieJar
 from pinterest_dl.low_level.api.endpoints import Endpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "pyexiv2",
     "requests",
     "deprecated",
-    "GitPython"
 ]
 
 [project.scripts]


### PR DESCRIPTION
The incorrect import of the git module is causing this library to install unnecessary modules.